### PR TITLE
chore: fix REUSE tool links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@ SPDX-FileCopyrightText: 2020 Andrew Lunde <andrew.lunde@sap.com>
 
 SPDX-License-Identifier: Apache-2.0
 -->
-[![REUSE status](https://api.reuse.software/badge/github.com/SAP-samples/cloud-sfsf-benefits-ext)](https://api.reuse.software/info/github.com/SAP-samples/cloud-sfsf-benefits-ext)
 
-# service management plugin for Cloud Foundry tools
+# Service management plugin for Cloud Foundry tools
+
+[![REUSE status](https://api.reuse.software/badge/github.com/SAP/cf-cli-smsi-plugin)](https://api.reuse.software/info/github.com/SAP/cf-cli-smsi-plugin)
 
 ## Description
 
@@ -121,4 +122,4 @@ In the subject of the pull request, use *feat:* to denote an enhancement, **fix:
 The Service Management plugin follows Semantic Versioning. These components strictly adhere to the [MAJOR].[MINOR].[PATCH] numbering system (also known as [BREAKING].[FEATURE].[FIX]).
 
 ## License
-Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This project is licensed under the Apache Software License, version 2.0 except as noted otherwise in the [LICENSE](LICENSES/Apache-2.0.txt) file.
+Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This project is licensed under the Apache Software License, version 2.0 except as noted otherwise in the [LICENSE](LICENSES/Apache-2.0.txt) file. Detailed information including third-party components and their licensing/copyright information is available [via the REUSE tool](https://api.reuse.software/info/github.com/SAP/cf-cli-smsi-plugin).


### PR DESCRIPTION
Fixes #7. Most certainly after the merge, you can also close #8 and #9.